### PR TITLE
Replaced IS_AND_OP and IS_OR_OP with OP_TYPE_IS_NN

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -604,6 +604,7 @@ Johannes Plunien		<plu@pqpq.de>
 John Bley			<jbb6@acpub.duke.edu>
 John Borwick			<jhborwic@unity.ncsu.edu>
 John Cerney			<j-cerney1@ti.com>
+John Deppe			<john.deppe@gmail.com>
 John D Groenveld		<groenvel@cse.psu.edu>
 John Gardiner Myers		<jgmyers@proofpoint.com>
 John Goodyear			<johngood@us.ibm.com>

--- a/op.c
+++ b/op.c
@@ -12834,8 +12834,6 @@ S_maybe_multideref(pTHX_ OP *start, OP *orig_o, UV orig_action, U8 hints)
     defer_queue[(defer_base + ++defer_ix) % MAX_DEFERRED] = &(o); \
   } STMT_END
 
-#define IS_AND_OP(o)   (o->op_type == OP_AND)
-#define IS_OR_OP(o)    (o->op_type == OP_OR)
 
 
 /* A peephole optimizer.  We visit the ops in the order they're to execute.
@@ -13649,8 +13647,13 @@ Perl_rpeep(pTHX_ OP *o)
                by the next op */
             if (o->op_next &&
                 (
-                    (IS_AND_OP(o) && IS_OR_OP(o->op_next))
-                 || (IS_OR_OP(o) && IS_AND_OP(o->op_next))
+                  (OP_TYPE_IS_NN(o, OP_AND)
+                  && 
+                  OP_TYPE_IS_NN(o->op_next, OP_OR))
+                ||
+                  (OP_TYPE_IS_NN(o, OP_OR)
+                  &&
+                  OP_TYPE_IS_NN(o->op_next, OP_AND))
                 )
                 && (o->op_next->op_flags & OPf_WANT) == OPf_WANT_VOID
             ) {


### PR DESCRIPTION
Replacing IS_AND_OP and IS_OR_OP solves them from the perspective of issue #18. Replacing OP_TYPE_IS_NN is issue #32's problem.
